### PR TITLE
[resolves #7] If offersearch is not available, keywordsearch is used instead

### DIFF
--- a/lambda/main/cortex.js
+++ b/lambda/main/cortex.js
@@ -183,7 +183,7 @@ Cortex.prototype.getItemBySku = function (sku) {
 }
 
 /**
- * Will query offersearch cortex resource, or kwywordsearch if offersearch is unavailable.
+ * Will query offersearch cortex resource, or keywordsearch if offersearch is unavailable.
  * @param  {[String]} keyword        - The keyword to be searched
  * @return {[Promise]} - Returns a promise
  */

--- a/lambda/main/cortex.js
+++ b/lambda/main/cortex.js
@@ -183,21 +183,25 @@ Cortex.prototype.getItemBySku = function (sku) {
 }
 
 /**
- * Will query offersearch cortex resource
+ * Will query offersearch cortex resource, or kwywordsearch if offersearch is unavailable.
  * @param  {[String]} keyword        - The keyword to be searched
  * @return {[Promise]} - Returns a promise
  */
 Cortex.prototype.getItemsByKeyword = function (keyword) {
     return new Promise((resolve, reject) => {
-        this.cortexGet(`${this.cortexBaseUrl}?zoom=searches:offersearchform:offersearchaction`)
+        this.cortexGet(`${this.cortexBaseUrl}?zoom=searches:offersearchform:offersearchaction,searches:keywordsearchform:itemkeywordsearchaction`)
         .then(data => {
             const zoom = [
                 'element:code',
                 'element:definition',
                 'element:price',
-                'element:availability'
+                'element:availability',
+                'element:items:element:code',
+                'element:items:element:definition',
+                'element:items:element:price',
+                'element:items:element:availability'
             ];
-            const url = data._searches[0]._offersearchform[0]._offersearchaction[0].self.href;
+            const url = (data._searches[0]._offersearchform) ? data._searches[0]._offersearchform[0]._offersearchaction[0].self.href : data._searches[0]._keywordsearchform[0]._itemkeywordsearchaction[0].self.href;
             return this.cortexPost(`${url}?followlocation&zoom=${zoom.join()}`, { keywords: keyword });
         })
         .then((data) => {

--- a/lambda/main/handlers/keywordsearch.handler.js
+++ b/lambda/main/handlers/keywordsearch.handler.js
@@ -39,8 +39,11 @@ const KeywordSearchHandler = {
                     if (data && data.length > 0) {
                         const attributes = attributesManager.getSessionAttributes();
                         const searchResults = [];
-                        data.forEach(item => searchResults.push(item._code[0].code));
-                        attributes.requestedSku = data[0]._code[0].code;
+                        data.forEach(item => {
+                            const code = (item._items) ? item._items[0]._element[0]._code[0].code : item._code[0].code;
+                            searchResults.push(code)
+                        });
+                        attributes.requestedSku = searchResults[0];
                         attributes.searchResults = searchResults;
                         attributesManager.setSessionAttributes(attributes);
                         speech = SpeechAssets.searchResults(data.length, data[0]);


### PR DESCRIPTION
Description:
If the `offersearch` resource is not available, the skill will use `keywordsearch` instead.

Linting:
- [x] No linting errors

Tests:
- [x] Manual tests
I have tested the intents on both 7.3 and 7.4 instances

Documentation:
- [ ] Requires documentation updates
